### PR TITLE
Bugfix: invalid file format detected.

### DIFF
--- a/css/simple-line-icons.css
+++ b/css/simple-line-icons.css
@@ -1,7 +1,11 @@
 @font-face {
   font-family: 'simple-line-icons';
-  src: url('../fonts/Simple-Line-Icons.eot?-i3a2kk');
-  src: url('../fonts/Simple-Line-Icons.eot?#iefix-i3a2kk') format('embedded-opentype'), url('../fonts/Simple-Line-Icons.ttf?-i3a2kk') format('truetype'), url('../fonts/Simple-Line-Icons.woff2?-i3a2kk') format('woff2'), url('../fonts/Simple-Line-Icons.woff?-i3a2kk') format('woff'), url('../fonts/Simple-Line-Icons.svg?-i3a2kk#simple-line-icons') format('svg');
+  src:url('../fonts/Simple-Line-Icons.eot');
+  src:url('../fonts/Simple-Line-Icons.eot?#iefix') format('embedded-opentype'),
+      url('../fonts/Simple-Line-Icons.ttf') format('truetype'),
+      url('../fonts/Simple-Line-Icons.woff2') format('woff2'),
+      url('../fonts/Simple-Line-Icons.woff') format('woff'),
+      url('../fonts/Simple-Line-Icons.svg#simple-line-icons') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Solves the following errors:
(from Chrome)
Failed to decode downloaded font: ...Simple-Line-Icons.ttf?-i3a2kk
OTS parsing error: invalid version tag
(from Explorer/Edge)
CSS3111: @font-face encountered unknown error.
File: Simple-Line-Icons.eot