### PR TITLE
Bugfix: invalid file format detected.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-line-icons",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "authors": [
     "Sabbir Ahmed <sabbiirr@gmail.com>"
   ],

--- a/css/simple-line-icons.css
+++ b/css/simple-line-icons.css
@@ -1,13 +1,17 @@
 @font-face {
   font-family: 'simple-line-icons';
-  src: url('../fonts/Simple-Line-Icons.eot?-i3a2kk');
-  src: url('../fonts/Simple-Line-Icons.eot?#iefix-i3a2kk') format('embedded-opentype'), url('../fonts/Simple-Line-Icons.ttf?-i3a2kk') format('truetype'), url('../fonts/Simple-Line-Icons.woff2?-i3a2kk') format('woff2'), url('../fonts/Simple-Line-Icons.woff?-i3a2kk') format('woff'), url('../fonts/Simple-Line-Icons.svg?-i3a2kk#simple-line-icons') format('svg');
+  src:  url('../fonts/Simple-Line-Icons.eot?v=2.2.2');
+  src:  url('../fonts/Simple-Line-Icons.eot?#iefix&v=2.2.2') format('embedded-opentype'),
+        url('../fonts/Simple-Line-Icons.ttf?v=2.2.2') format('truetype'),
+        url('../fonts/Simple-Line-Icons.woff2?v=2.2.2') format('woff2'),
+        url('../fonts/Simple-Line-Icons.woff?v=2.2.2') format('woff'),
+        url('../fonts/Simple-Line-Icons.svg?v=2.2.2#simple-line-icons') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 /*
  Use the following CSS code if you want to have a class per icon.
- Instead of a list of all class selectors, you can use the generic [class*="icon-"] selector, but it's slower: 
+ Instead of a list of all class selectors, you can use the generic [class*="icon-"] selector, but it's slower:
 */
 .icon-user,
 .icon-people,

--- a/less/simple-line-icons.less
+++ b/less/simple-line-icons.less
@@ -6,23 +6,23 @@
 //Fonts
 @font-face {
   font-family: '@{simple-line-font-family}';
-  src: url('@{simple-line-font-path}Simple-Line-Icons.eot?-i3a2kk');
-  src: url('@{simple-line-font-path}Simple-Line-Icons.eot?#iefix-i3a2kk') format('embedded-opentype'),
-  url('@{simple-line-font-path}Simple-Line-Icons.ttf?-i3a2kk') format('truetype'),
-  url('@{simple-line-font-path}Simple-Line-Icons.woff2?-i3a2kk') format('woff2'),
-  url('@{simple-line-font-path}Simple-Line-Icons.woff?-i3a2kk') format('woff'),
-  url('@{simple-line-font-path}Simple-Line-Icons.svg?-i3a2kk#simple-line-icons') format('svg');
+  src:  url('@{simple-line-font-path}Simple-Line-Icons.eot?v=2.2.2');
+  src:  url('@{simple-line-font-path}Simple-Line-Icons.eot?#iefix&v=2.2.2') format('embedded-opentype'),
+        url('@{simple-line-font-path}Simple-Line-Icons.ttf?v=2.2.2') format('truetype'),
+        url('@{simple-line-font-path}Simple-Line-Icons.woff2?v=2.2.2') format('woff2'),
+        url('@{simple-line-font-path}Simple-Line-Icons.woff?v=2.2.2') format('woff'),
+        url('@{simple-line-font-path}Simple-Line-Icons.svg?v=2.2.2#simple-line-icons') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 /*
  Use the following CSS code if you want to have a class per icon.
- Instead of a list of all class selectors, you can use the generic [class*="icon-"] selector, but it's slower: 
+ Instead of a list of all class selectors, you can use the generic [class*="icon-"] selector, but it's slower:
 */
 
 .@{simple-line-icon-prefix}  {
-    &user,
+  &user,
   &people,
   &user-female,
   &user-follow,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-line-icons",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Simple and elegent line icons.",
   "main": "index.js",
   "scripts": {

--- a/scss/simple-line-icons.scss
+++ b/scss/simple-line-icons.scss
@@ -7,12 +7,12 @@ $simple-line-icon-prefix: "icon-" !default;
 @if $simple-line-font-family == "simple-line-icons" {
   @font-face {
     font-family: '#{$simple-line-font-family}';
-    src: url('#{$simple-line-font-path}Simple-Line-Icons.eot?-i3a2kk');
-    src: url('#{$simple-line-font-path}Simple-Line-Icons.eot?#iefix-i3a2kk') format('embedded-opentype'),
-    url('#{$simple-line-font-path}Simple-Line-Icons.ttf?-i3a2kk') format('truetype'),
-    url('#{$simple-line-font-path}Simple-Line-Icons.woff2?-i3a2kk') format('woff2'),
-    url('#{$simple-line-font-path}Simple-Line-Icons.woff?-i3a2kk') format('woff'),
-    url('#{$simple-line-font-path}Simple-Line-Icons.svg?-i3a2kk#simple-line-icons') format('svg');
+    src:    url('#{$simple-line-font-path}Simple-Line-Icons.eot?v=2.2.2');
+    src:    url('#{$simple-line-font-path}Simple-Line-Icons.eot?#iefix&v=2.2.2') format('embedded-opentype'),
+            url('#{$simple-line-font-path}Simple-Line-Icons.ttf?v=2.2.2') format('truetype'),
+            url('#{$simple-line-font-path}Simple-Line-Icons.woff2?v=2.2.2') format('woff2'),
+            url('#{$simple-line-font-path}Simple-Line-Icons.woff?v=2.2.2') format('woff'),
+            url('#{$simple-line-font-path}Simple-Line-Icons.svg?v=2.2.2#simple-line-icons') format('svg');
     font-weight: normal;
     font-style: normal;
   }


### PR DESCRIPTION
Solves the following errors:
(from Chrome)
Failed to decode downloaded font: ...Simple-Line-Icons.ttf?-i3a2kk
OTS parsing error: invalid version tag
(from Explorer/Edge)
CSS3111: @font-face encountered unknown error.
File: Simple-Line-Icons.eot