### PR TITLE
Fix for the IE EOT URI Bug.

### DIFF
--- a/css/simple-line-icons.css
+++ b/css/simple-line-icons.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'simple-line-icons';
   src: url('../fonts/Simple-Line-Icons.eot?v=2.2.2');
-  src: url('../fonts/Simple-Line-Icons.eot?#iefix&v=2.2.2') format('embedded-opentype'), url('../fonts/Simple-Line-Icons.ttf?v=2.2.2') format('truetype'), url('../fonts/Simple-Line-Icons.woff2?v=2.2.2') format('woff2'), url('../fonts/Simple-Line-Icons.woff?v=2.2.2') format('woff'), url('../fonts/Simple-Line-Icons.svg?v=2.2.2#simple-line-icons') format('svg');
+  src: url('../fonts/Simple-Line-Icons.eot?v=2.2.2#iefix') format('embedded-opentype'), url('../fonts/Simple-Line-Icons.ttf?v=2.2.2') format('truetype'), url('../fonts/Simple-Line-Icons.woff2?v=2.2.2') format('woff2'), url('../fonts/Simple-Line-Icons.woff?v=2.2.2') format('woff'), url('../fonts/Simple-Line-Icons.svg?v=2.2.2#simple-line-icons') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/less/simple-line-icons.less
+++ b/less/simple-line-icons.less
@@ -7,7 +7,7 @@
 @font-face {
   font-family: '@{simple-line-font-family}';
   src:  url('@{simple-line-font-path}Simple-Line-Icons.eot?v=2.2.2');
-  src:  url('@{simple-line-font-path}Simple-Line-Icons.eot?#iefix&v=2.2.2') format('embedded-opentype'),
+  src:  url('@{simple-line-font-path}Simple-Line-Icons.eot?v=2.2.2#iefix') format('embedded-opentype'),
         url('@{simple-line-font-path}Simple-Line-Icons.ttf?v=2.2.2') format('truetype'),
         url('@{simple-line-font-path}Simple-Line-Icons.woff2?v=2.2.2') format('woff2'),
         url('@{simple-line-font-path}Simple-Line-Icons.woff?v=2.2.2') format('woff'),

--- a/scss/simple-line-icons.scss
+++ b/scss/simple-line-icons.scss
@@ -8,7 +8,7 @@ $simple-line-icon-prefix: "icon-" !default;
   @font-face {
     font-family: '#{$simple-line-font-family}';
     src:    url('#{$simple-line-font-path}Simple-Line-Icons.eot?v=2.2.2');
-    src:    url('#{$simple-line-font-path}Simple-Line-Icons.eot?#iefix&v=2.2.2') format('embedded-opentype'),
+    src:    url('#{$simple-line-font-path}Simple-Line-Icons.eot?v=2.2.2#iefix') format('embedded-opentype'),
             url('#{$simple-line-font-path}Simple-Line-Icons.ttf?v=2.2.2') format('truetype'),
             url('#{$simple-line-font-path}Simple-Line-Icons.woff2?v=2.2.2') format('woff2'),
             url('#{$simple-line-font-path}Simple-Line-Icons.woff?v=2.2.2') format('woff'),


### PR DESCRIPTION
* Replaced `?#iefix&v=2.2.2` with `?v=2.2.2#iefix`.
* Fixes #43.