### PR TITLE
Added sass/less build test, precommit hook, travis test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.log
 *~
 *#
+node_modules/
+build/
+!.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "6"
+cache:
+  directories:
+    - node_modules
+before_install:
+  - npm install -g npm
+install:
+  - npm install
+sudo: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,25 @@
+var gulp = require('gulp'),
+    sass = require('gulp-sass'),
+    less = require('gulp-less');
+
+var paths = {
+    less: 'less/simple-line-icons.less',
+    sass: 'scss/simple-line-icons.scss',
+    build: 'build/'
+};
+
+gulp.task('less', function(){
+    return gulp.src(paths.less)
+    .pipe(less())
+    .pipe(gulp.dest(paths.build));
+});
+
+gulp.task('sass', function(){
+    return gulp.src(paths.sass)
+    .pipe(sass())
+    .pipe(gulp.dest(paths.build));
+});
+
+gulp.task('test', ['less', 'sass']);
+
+gulp.task('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple and elegent line icons.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "precommit": "npm test",
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
@@ -22,5 +23,11 @@
   "bugs": {
     "url": "https://github.com/thesabbir/simple-line-icons/issues"
   },
-  "homepage": "https://thesabbir.github.io/simple-line-icons"
+  "homepage": "https://thesabbir.github.io/simple-line-icons",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-less": "^3.1.0",
+    "gulp-sass": "^2.3.2",
+    "husky": "^0.11.8"
+  }
 }


### PR DESCRIPTION
This is a starting ground and it's very basic at the moment. It ensures that the less and sass files build without errors.

This is related to the issue #62 I opened today and could help bootstrap with the (older) issue #52.

To use the new test and commit hooks, simply install the dependencies with:

```
npm install
```

The rest is automagic.

If you want to manually test the build, use the `npm test` command.

There's also a `.travis.yml` file which replicates the test server side validating the build for each commits and pull requests.